### PR TITLE
fix syntax check on mac

### DIFF
--- a/src/chuckSyntaxCheckProvider.ts
+++ b/src/chuckSyntaxCheckProvider.ts
@@ -32,7 +32,7 @@ export default class ChuckSyntaxCheckProvider {
     // will actually go into the config in memory, and be in the args of our next syntax check.
     const args: string[] = [...(this.config.get("syntaxCheckArgs") as string[])];
     const fileName = fixMSWindowsPath(this.document.fileName);
-    args.push(`"${fileName}"`);
+    args.push(fileName);
     const options: cp.SpawnOptions = { cwd: path.dirname(fileName) };
     if (runningOnMSWindows()) {
       options.shell = true;


### PR DESCRIPTION
I noticed that syntax error highlighting wasn't working for me.

When I tried debugging the Extension itself, it suggested a file not found error:

```
Recevied stderr data event with
[chuck]: no such file: 'test.ck"'
```

The previous code wrapped the path in double quotes, then passed it to `cp.spawn`. That means that it was equivalent to passing a quoted value at the command line.

You can reproduce the problem outside of the extension like so:

```
$ chuck '"/Users/nathanleiby/test.ck"'
[chuck]: no such file: 'test.ck"'
```

Notice the trailing `"` in the no such file error. It seems that `chuck` command isn't able to handle the additional quotes.

I suggest removing them. This caused syntax highlighting to start working for me!

---

I'm running chuck 1.5.5.2

```
$ chuck --version

chuck version: 1.5.5.2 (chai)
   macOS | 64-bit [universal binary]
   audio driver: CoreAudio
   http://chuck.cs.princeton.edu/
   http://chuck.stanford.edu/
```